### PR TITLE
Bump requirements to make Flask code example functional

### DIFF
--- a/api/back-end/python/flask/requirements.txt
+++ b/api/back-end/python/flask/requirements.txt
@@ -1,9 +1,9 @@
 chargebee==2.4.5
 click==6.7
 Flask==1.1.2
-Flask-Cors==3.0.3
+Flask-Cors==3.0.10
 itsdangerous==0.24
 Jinja2==2.11.3
-MarkupSafe==1.0
+MarkupSafe==2.0.1
 six==1.11.0
 Werkzeug==1.0.1


### PR DESCRIPTION
Bump Flask-cors and MarkupSafe version.
Tested with Python 3.10